### PR TITLE
Fix go-ipfs recipes and add ARCH input variable

### DIFF
--- a/ProtocolLabs/go-ipfs.download.recipe
+++ b/ProtocolLabs/go-ipfs.download.recipe
@@ -3,13 +3,20 @@
 <plist version="1.0">
 <dict>
 	<key>Description</key>
-	<string>Downloads the latest go-ipfs release</string>
+	<string>Downloads the latest Kubo (formerly known as go-ipfs) release.
+	
+Valid values for ARCH include:
+- amd64 (default, Intel)
+- arm64 (Apple Silicon)
+</string>
 	<key>Identifier</key>
 	<string>com.github.natewalck.download.go-ipfs</string>
 	<key>Input</key>
 	<dict>
 		<key>NAME</key>
 		<string>go-ipfs</string>
+		<key>ARCH</key>
+		<string>amd64</string>
 	</dict>
 	<key>MinimumVersion</key>
 	<string>1.4</string>
@@ -21,9 +28,9 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://dist.ipfs.io</string>
+				<string>https://dist.ipfs.tech/#kubo</string>
 				<key>re_pattern</key>
-				<string>(?P&lt;url&gt;go-ipfs/v(.*)/go-ipfs_v(?P&lt;version&gt;[\d\.]+)\_darwin-amd64\.tar\.gz)</string>
+				<string>href="(?P&lt;url&gt;kubo/v[\d\.]+/kubo_v(?P&lt;version&gt;[\d\.])+_darwin-%ARCH%\.tar\.gz)"</string>
 			</dict>
 		</dict>
 		<dict>
@@ -32,7 +39,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://dist.ipfs.io/%url%</string>
+				<string>https://dist.ipfs.tech/%url%</string>
 				<key>filename</key>
 				<string>%NAME%-%version%_darwin-amd64.tar.gz</string>
 			</dict>
@@ -47,7 +54,7 @@
 			<key>Arguments</key>
 			<dict>
 				<key>url</key>
-				<string>https://dist.ipfs.io/go-ipfs/v%version%/go-ipfs_v%version%_darwin-amd64.tar.gz.sha512</string>
+				<string>%url%.sha512</string>
 				<key>re_pattern</key>
 				<string>(?P&lt;checksum&gt;\w+)</string>
 			</dict>


### PR DESCRIPTION
This PR adjusts the go-ipfs recipes to download kubo, the latest release of go-ipfs. It also adds an ARCH variable to specify which architecture to download.

Verbose recipe run output with default (Intel) architecture:

```
% autopkg run -vvq 'ProtocolLabs/go-ipfs.download.recipe'
Processing ProtocolLabs/go-ipfs.download.recipe...
WARNING: ProtocolLabs/go-ipfs.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(?P<url>kubo/v[\\d\\.]+/kubo_v(?P<version>[\\d\\.])+_darwin-amd64\\.tar\\.gz)"',
           'url': 'https://dist.ipfs.tech/#kubo'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): kubo/v0.32.1/kubo_v0.32.1_darwin-amd64.tar.gz
URLTextSearcher: Found matching text (version): 1
URLTextSearcher: Found matching text (match): kubo/v0.32.1/kubo_v0.32.1_darwin-amd64.tar.gz
{'Output': {'match': 'kubo/v0.32.1/kubo_v0.32.1_darwin-amd64.tar.gz',
            'url': 'kubo/v0.32.1/kubo_v0.32.1_darwin-amd64.tar.gz',
            'version': '1'}}
URLDownloader
{'Input': {'filename': 'go-ipfs-1_darwin-amd64.tar.gz',
           'url': 'https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_darwin-amd64.tar.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 27 Dec 2024 20:27:18 GMT
URLDownloader: Storing new ETag header: "QmaS5PRfbnYH91eaLg97MtZ6J3k11H4zQaLvX5tZANSjZ5"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz
{'Output': {'download_changed': True,
            'etag': '"QmaS5PRfbnYH91eaLg97MtZ6J3k11H4zQaLvX5tZANSjZ5"',
            'last_modified': 'Fri, 27 Dec 2024 20:27:18 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': '(?P<checksum>\\w+)',
           'result_output_var_name': 'match',
           'url': 'https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_darwin-amd64.tar.gz.sha512'}}
URLTextSearcher: Found matching text (checksum): 4ee48be2b9ae678eb772cc276845b5972372595ffc87185d75ea30c08366434347277a1093b28383cf4c42b57c6224b7a2f7173108c45d6398105192e145b0ee
URLTextSearcher: Found matching text (match): 4ee48be2b9ae678eb772cc276845b5972372595ffc87185d75ea30c08366434347277a1093b28383cf4c42b57c6224b7a2f7173108c45d6398105192e145b0ee
{'Output': {'checksum': '4ee48be2b9ae678eb772cc276845b5972372595ffc87185d75ea30c08366434347277a1093b28383cf4c42b57c6224b7a2f7173108c45d6398105192e145b0ee',
            'match': '4ee48be2b9ae678eb772cc276845b5972372595ffc87185d75ea30c08366434347277a1093b28383cf4c42b57c6224b7a2f7173108c45d6398105192e145b0ee'}}
io.github.hjuutilainen.SharedProcessors/ChecksumVerifier
{'Input': {'algorithm': 'SHA512',
           'checksum': '4ee48be2b9ae678eb772cc276845b5972372595ffc87185d75ea30c08366434347277a1093b28383cf4c42b57c6224b7a2f7173108c45d6398105192e145b0ee',
           'pathname': '~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz'}}
ChecksumVerifier: Calculating SHA512 checksum for ~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz
ChecksumVerifier: Calculated checksum: 4ee48be2b9ae678eb772cc276845b5972372595ffc87185d75ea30c08366434347277a1093b28383cf4c42b57c6224b7a2f7173108c45d6398105192e145b0ee
ChecksumVerifier: Expected checksum:   4ee48be2b9ae678eb772cc276845b5972372595ffc87185d75ea30c08366434347277a1093b28383cf4c42b57c6224b7a2f7173108c45d6398105192e145b0ee
ChecksumVerifier: Calculated checksum matches the expected checksum.
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/receipts/go-ipfs.download-receipt-20241227-122725.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz
```

Verbose recipe run output with Apple Silicon architecture:

```
% autopkg run -vvq 'ProtocolLabs/go-ipfs.download.recipe' -k ARCH=arm64
Processing ProtocolLabs/go-ipfs.download.recipe...
WARNING: ProtocolLabs/go-ipfs.download.recipe is missing trust info and FAIL_RECIPES_WITHOUT_TRUST_INFO is not set. Proceeding...
URLTextSearcher
{'Input': {'re_pattern': 'href="(?P<url>kubo/v[\\d\\.]+/kubo_v(?P<version>[\\d\\.])+_darwin-arm64\\.tar\\.gz)"',
           'url': 'https://dist.ipfs.tech/#kubo'}}
URLTextSearcher: No value supplied for result_output_var_name, setting default value of: match
URLTextSearcher: Found matching text (url): kubo/v0.32.1/kubo_v0.32.1_darwin-arm64.tar.gz
URLTextSearcher: Found matching text (version): 1
URLTextSearcher: Found matching text (match): kubo/v0.32.1/kubo_v0.32.1_darwin-arm64.tar.gz
{'Output': {'match': 'kubo/v0.32.1/kubo_v0.32.1_darwin-arm64.tar.gz',
            'url': 'kubo/v0.32.1/kubo_v0.32.1_darwin-arm64.tar.gz',
            'version': '1'}}
URLDownloader
{'Input': {'filename': 'go-ipfs-1_darwin-amd64.tar.gz',
           'url': 'https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_darwin-arm64.tar.gz'}}
URLDownloader: No value supplied for prefetch_filename, setting default value of: False
URLDownloader: No value supplied for CHECK_FILESIZE_ONLY, setting default value of: False
URLDownloader: Storing new Last-Modified header: Fri, 27 Dec 2024 20:27:35 GMT
URLDownloader: Storing new ETag header: "QmUF5CthH7Sp363etqVnZzPJeiEQZxmxNrnN2sWTd5z573"
URLDownloader: Downloaded ~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz
{'Output': {'download_changed': True,
            'etag': '"QmUF5CthH7Sp363etqVnZzPJeiEQZxmxNrnN2sWTd5z573"',
            'last_modified': 'Fri, 27 Dec 2024 20:27:35 GMT',
            'pathname': '~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz',
            'url_downloader_summary_result': {'data': {'download_path': '~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz'},
                                              'summary_text': 'The following '
                                                              'new items were '
                                                              'downloaded:'}}}
EndOfCheckPhase
{'Input': {}}
{'Output': {}}
URLTextSearcher
{'Input': {'re_pattern': '(?P<checksum>\\w+)',
           'result_output_var_name': 'match',
           'url': 'https://dist.ipfs.tech/kubo/v0.32.1/kubo_v0.32.1_darwin-arm64.tar.gz.sha512'}}
URLTextSearcher: Found matching text (checksum): fb14edf24a6f42a664af180ed07659d47866ed7a4d023e5be40322526daed8ba792bb337cb51502f2cf51fa9247ca53b0dc07b57b94ca3002fdf3adb90a3b0de
URLTextSearcher: Found matching text (match): fb14edf24a6f42a664af180ed07659d47866ed7a4d023e5be40322526daed8ba792bb337cb51502f2cf51fa9247ca53b0dc07b57b94ca3002fdf3adb90a3b0de
{'Output': {'checksum': 'fb14edf24a6f42a664af180ed07659d47866ed7a4d023e5be40322526daed8ba792bb337cb51502f2cf51fa9247ca53b0dc07b57b94ca3002fdf3adb90a3b0de',
            'match': 'fb14edf24a6f42a664af180ed07659d47866ed7a4d023e5be40322526daed8ba792bb337cb51502f2cf51fa9247ca53b0dc07b57b94ca3002fdf3adb90a3b0de'}}
io.github.hjuutilainen.SharedProcessors/ChecksumVerifier
{'Input': {'algorithm': 'SHA512',
           'checksum': 'fb14edf24a6f42a664af180ed07659d47866ed7a4d023e5be40322526daed8ba792bb337cb51502f2cf51fa9247ca53b0dc07b57b94ca3002fdf3adb90a3b0de',
           'pathname': '~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz'}}
ChecksumVerifier: Calculating SHA512 checksum for ~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz
ChecksumVerifier: Calculated checksum: fb14edf24a6f42a664af180ed07659d47866ed7a4d023e5be40322526daed8ba792bb337cb51502f2cf51fa9247ca53b0dc07b57b94ca3002fdf3adb90a3b0de
ChecksumVerifier: Expected checksum:   fb14edf24a6f42a664af180ed07659d47866ed7a4d023e5be40322526daed8ba792bb337cb51502f2cf51fa9247ca53b0dc07b57b94ca3002fdf3adb90a3b0de
ChecksumVerifier: Calculated checksum matches the expected checksum.
{'Output': {}}
Receipt written to ~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/receipts/go-ipfs.download-receipt-20241227-122744.plist

The following new items were downloaded:
    Download Path
    -------------
    ~/Library/AutoPkg/Cache/com.github.natewalck.download.go-ipfs/downloads/go-ipfs-1_darwin-amd64.tar.gz
```
